### PR TITLE
Streaming RTR GET File Downloads

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   codeql:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/caracara/modules/rtr/get_file.py
+++ b/caracara/modules/rtr/get_file.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
 
 import py7zr
 import py7zr.callbacks
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     # This trick will avoid us from causing a cyclical reference within the class
     # Credit: https://stackoverflow.com/a/39757388
     from falconpy import RealTimeResponse
+
     from caracara import Client
     from caracara.modules.rtr.batch_session import RTRBatchSession
 

--- a/caracara/modules/rtr/get_file.py
+++ b/caracara/modules/rtr/get_file.py
@@ -4,24 +4,61 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 
 import py7zr
+import py7zr.callbacks
+from tqdm import tqdm
 
 if TYPE_CHECKING:
     # This trick will avoid us from causing a cyclical reference within the class
     # Credit: https://stackoverflow.com/a/39757388
+    from falconpy import RealTimeResponse
+    from caracara import Client
     from caracara.modules.rtr.batch_session import RTRBatchSession
+
+
+class SevenZipExtractProgressBar(py7zr.callbacks.ExtractCallback, tqdm):
+    """A progress bar extractor for py7zr.
+
+    This code is heavily based on an example published on GitHub here:
+        https://github.com/miurahr/py7zr/pull/558
+    """
+    def __init__(self, *args, total_bytes: int, **kwargs):
+            super().__init__(self, *args, total=total_bytes, **kwargs)
+
+    def report_start_preparation(self):
+        pass
+    
+    def report_start(self, processing_file_path, processing_bytes):
+        pass
+
+    def report_end(self, processing_file_path, wrote_bytes):
+        pass
+
+    def report_update(self, decompressed_bytes):
+        self.update(int(decompressed_bytes))
+
+    def report_postprocess(self):
+        pass
+
+    def report_warning(self, message):
+        pass
 
 
 @dataclass
 class GetFile:
-    """
-    Represents a file uploaded to Falcon via a GET command.
+    """Represent a file uploaded to Falcon via a GET command.
 
     This class may be instantiated many times, with each object stored in a common list,
     in order to represent many files retrieved from a GET comamnd executed against a
     batch session.
+
+    Only one of batch_session, client, or rtr_api need to be set. When the rtr_api property
+    is called, a RealTimeResponse object will be returned according to this priority list:
+    - _rtr_api (i.e., rtr_api is set via the GetFile object's property setter)
+    - client.rtr.rtr_api
+    - batch_session.api
     """
 
     device_id: str = None
@@ -30,19 +67,68 @@ class GetFile:
     sha256: str = None
     size: int = None
     batch_session: RTRBatchSession = None
+    client: Client = None
+    _rtr_api: RealTimeResponse = None
+
+    @property
+    def rtr_api(self) -> RealTimeResponse:
+        if self._rtr_api:
+            return self._rtr_api
+        if self.client:
+            return self.client.rtr.rtr_api
+        if self.batch_session:
+            return self.batch_session.api
+        raise AttributeError(
+            "You must set at least one of batch_session, client, or rtr_api, so that this object "
+            "can access the FalconPy Real Time Response API wrapper."
+        )
+
+    @rtr_api.setter
+    def rtr_api(self, v: RealTimeResponse) -> None:
+        self._rtr_api = v
 
     def download(
         self,
         output_path: str,
         extract: bool = True,
         preserve_7z: bool = False,
+        show_download_progress: bool = False,
+        download_chunk_size: int = 1048576,  # 1MiB
     ):
-        """
-        Download a file to a specified path.
+        """Download a file to a specified path.
 
         If the path is a folder, the filename will be auto generated.
         If the path is a file, it'll be downloaded to that path and name.
+
+        All downloads require that the following three attributes be set in the GetFile object:
+        - session_id (RTR Session ID)
+        - sha256 (SHA256 hash of the extracted file)
+        - filename (name of the extracted file)
+        These three values are all returned when the status of a GET command is queried.
+
+        Additionally, this function requires that a Device ID (AID) be stored within the GetFile
+        object to include the Device ID in the eventual filename. If this is not provided, and
+        output_path is set to a directory, the AID will be excluded from the calculated eventual
+        file name. Note that this is irrelevant if output_path is NOT a path to a directory, as
+        the filename provided to this parameter will be used instead of one derived by the library.
+
+        Other parameters:
+        - show_download_progress: Whether or not to draw the download progress via TQDM.
+        - download_chunk_size: Size of each chunk to stream via requests. Defaults to 1MiB.
+                               If this is set to 0, chunking will not be used.
         """
+        if (
+            not self.session_id or
+            not self.sha256 or
+            not self.filename 
+        ):
+            raise ValueError(
+                "A session ID, SHA256 hash, and filename are all required to download a GET file. "
+                "Ensure these values are set in the object before calling the download function."
+            )
+
+        # Get the name of the uploaded file from the filename value, which actually contains the
+        # full path to the file on the origin system's disk.
         if self.filename.startswith("/"):
             # macOS or *nix path
             filename = self.filename.rsplit("/", maxsplit=1)[-1]
@@ -52,11 +138,20 @@ class GetFile:
 
         filename_noext, ext = os.path.splitext(filename)
 
+        # Figure out what the file should be named.
+        # If a directory is provided as an output, we rename the file according to its name,
+        # hash and origin device AID.
+        # Otherwise, we use the exact filename provided as a parameter.
         if os.path.isdir(output_path):
             # Output path is a folder, so we should compute the filename
+            if self.device_id:
+                output_filename = f"{filename_noext}_{self.sha256}_{self.device_id}{ext}",
+            else:
+                output_filename = f"{filename_noext}_{self.sha256}{ext}"
+
             full_output_path = os.path.join(
                 output_path,
-                f"{filename_noext}_{self.sha256}_{self.device_id}{ext}",
+                output_filename,
             )
             full_output_path_7z = full_output_path + ".7z"
         else:
@@ -70,29 +165,95 @@ class GetFile:
                 else:
                     full_output_path_7z = full_output_path + ".7z"
 
-        file_contents = self.batch_session.api.get_extracted_file_contents(
-            session_id=self.session_id,
-            sha256=self.sha256,
-            filename=self.filename,
-        )
+        # Chunked downloads can be disabled by providing a 0 as the chunk size.
+        # This is rarely advantageous, but is provided for compatability.
+        # Non-chunked downloads do not support progress bars, so we just skip the tqdm invocation
+        # if download_chunk_size = 0, and instead write the file straight to disk from memory.
+        if download_chunk_size == 0:
+            file_contents = self.rtr_api.get_extracted_file_contents(
+                session_id=self.session_id,
+                sha256=self.sha256,
+                filename=self.filename,
+            )
+            with open(full_output_path_7z, "wb") as output_7z_file:
+                output_7z_file.write(file_contents)
+        else:
+            get_file_response = self.rtr_api.get_extracted_file_contents(
+                session_id=self.session_id,
+                sha256=self.sha256,
+                filename=self.filename,
+                stream=True,
+            )
 
-        with open(full_output_path_7z, "wb") as output_7z_file:
-            output_7z_file.write(file_contents)
+            if show_download_progress:
+                with tqdm.wrapattr(
+                    stream=open(full_output_path_7z, "wb"),
+                    method="write",
+                    total=0,  # Content-Length header is not sent by RTR, so tqdm will count upwards
+                    miniters=1,
+                    bytes=True,
+                    desc=os.path.basename(full_output_path_7z),
+                ) as output_7z_file:
+                    for chunk in get_file_response.iter_content(chunk_size=download_chunk_size):
+                        output_7z_file.write(chunk)
+
+                    # We have to manually close the file once the download is complete, or chunk
+                    # data will not be flushed to disk and the 7-Zip archive will be unreadable by
+                    # py7zr. See: https://github.com/tqdm/tqdm/issues/1247
+                    output_7z_file.close()
+            else:
+                # If no progress bar is requested, we still use chunking to avoid storing the whole
+                # 7-Zip archive into memory before writing it to disk.
+                with open(full_output_path_7z, "wb") as output_7z_file:
+                    for chunk in get_file_response.iter_content(chunk_size=download_chunk_size):
+                        output_7z_file.write(chunk)
 
         if not extract:
             # Downloaded, so we're done now!
             return
 
-        with py7zr.SevenZipFile(  # nosec - The password 'infected' is generic and always the same
+        target_dir = os.path.dirname(full_output_path_7z)
+
+        with py7zr.SevenZipFile(  # nosec - The password "infected" is generic and always the same
             file=full_output_path_7z,
             mode="r",
             password="infected",
         ) as archive:
-            target_dir = os.path.dirname(full_output_path_7z)
-            archive.extract(path=target_dir)
+            archive_filenames = archive.getnames()
+            if show_download_progress:
+                archive_info = archive.archiveinfo()
+                with SevenZipExtractProgressBar(
+                    unit="B",
+                    unit_scale=True,
+                    miniters=1,
+                    total_bytes=archive_info.uncompressed,
+                    desc=f"Extracting...",
+                    ascii=True,
+                ) as progress:
+                    # archive.extract() does not provide a callback parameter, but behaviour should
+                    # not differ since RTR 7-Zip archives should always contain exactly one inner
+                    # file.
+                    archive.extractall(path=target_dir, callback=progress)
+            else:
+                archive.extract(path=target_dir)
 
-            if not preserve_7z:
-                os.unlink(full_output_path_7z)
+        # Check that we truly only received exactly one output file in the 7-Zip archive.
+        # If all is well, we rename the first (and hopefully only) output file to match the name
+        # derived at the beginning of this function.
+        if archive_filenames and len(archive_filenames) == 1:
+            orig_filename = archive_filenames[0]
+            orig_path = os.path.join(target_dir, orig_filename)
+            os.rename(orig_path, full_output_path)
+        else:
+            raise ValueError(
+                "The downloaded 7-Zip archive contains the wrong number of files. Contents: %s",
+                str(archive_filenames),
+            )
+
+        # Delete the 7-Zip archive after extracting its contents if the developer told us it
+        # does not need to be preserved.
+        if not preserve_7z:
+            os.unlink(full_output_path_7z)
 
     def __str__(self):
         """Return a loggable string representing the contents of the object."""

--- a/caracara/modules/rtr/get_file.py
+++ b/caracara/modules/rtr/get_file.py
@@ -134,10 +134,7 @@ class GetFile:
         return full_output_path, full_output_path_7z
 
     def _extract_downloaded_7z(
-            self,
-            archive_path: str,
-            output_path: str,
-            show_extraction_progress: bool
+        self, archive_path: str, output_path: str, show_extraction_progress: bool
     ) -> None:
         """Extract the downloaded 7-Zip archive if requested."""
         target_dir = os.path.dirname(archive_path)
@@ -208,11 +205,7 @@ class GetFile:
         - download_chunk_size: Size of each chunk to stream via requests. Defaults to 1MiB.
                                If this is set to 0, chunking will not be used.
         """
-        if (
-            not self.session_id or
-            not self.sha256 or
-            not self.filename
-        ):
+        if not self.session_id or not self.sha256 or not self.filename:
             raise ValueError(
                 "A session ID, SHA256 hash, and filename are all required to download a GET file. "
                 "Ensure these values are set in the object before calling the download function."

--- a/caracara/modules/rtr/get_file.py
+++ b/caracara/modules/rtr/get_file.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import List, Optional, TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING
 
 import py7zr
 import py7zr.callbacks
@@ -24,26 +24,29 @@ class SevenZipExtractProgressBar(py7zr.callbacks.ExtractCallback, tqdm):
     This code is heavily based on an example published on GitHub here:
         https://github.com/miurahr/py7zr/pull/558
     """
+
     def __init__(self, *args, total_bytes: int, **kwargs):
-            super().__init__(self, *args, total=total_bytes, **kwargs)
+        """Initialise the progress bar."""
+        super().__init__(self, *args, total=total_bytes, **kwargs)
 
     def report_start_preparation(self):
-        pass
-    
+        """No start preparation callback needed."""
+
     def report_start(self, processing_file_path, processing_bytes):
-        pass
+        """No start callback needed."""
 
     def report_end(self, processing_file_path, wrote_bytes):
-        pass
+        """No end callback needed."""
 
     def report_update(self, decompressed_bytes):
+        """Update the progress bar."""
         self.update(int(decompressed_bytes))
 
     def report_postprocess(self):
-        pass
+        """No post-process callback needed."""
 
     def report_warning(self, message):
-        pass
+        """No warning callback needed."""
 
 
 @dataclass
@@ -72,6 +75,7 @@ class GetFile:
 
     @property
     def rtr_api(self) -> RealTimeResponse:
+        """Property that returns an authenticated RealTimeResponse FalconPy object."""
         if self._rtr_api:
             return self._rtr_api
         if self.client:
@@ -86,6 +90,93 @@ class GetFile:
     @rtr_api.setter
     def rtr_api(self, v: RealTimeResponse) -> None:
         self._rtr_api = v
+
+    def _download_derive_output_paths(self, output_path: str, extract: bool) -> Tuple[str, str]:
+        """Derive the output filename of a GET file downloaded from the CrowdStrike cloud."""
+        # Get the name of the uploaded file from the filename value, which actually contains the
+        # full path to the file on the origin system's disk.
+        if self.filename.startswith("/"):
+            # macOS or *nix path
+            filename = self.filename.rsplit("/", maxsplit=1)[-1]
+        else:
+            # Windows filename
+            filename = self.filename.rsplit("\\", maxsplit=1)[-1]
+
+        filename_noext, ext = os.path.splitext(filename)
+
+        # Figure out what the file should be named.
+        # If a directory is provided as an output, we rename the file according to its name,
+        # hash and origin device AID.
+        # Otherwise, we use the exact filename provided as a parameter.
+        if os.path.isdir(output_path):
+            # Output path is a folder, so we should compute the filename
+            if self.device_id:
+                output_filename = f"{filename_noext}_{self.sha256}_{self.device_id}{ext}"
+            else:
+                output_filename = f"{filename_noext}_{self.sha256}{ext}"
+
+            full_output_path = os.path.join(
+                output_path,
+                output_filename,
+            )
+            full_output_path_7z = full_output_path + ".7z"
+        else:
+            full_output_path = output_path
+            if extract:
+                full_output_path_7z = full_output_path + ".7z"
+            else:
+                # We should ensure that the user's path ends in .7z if they are not extracting
+                if full_output_path.endswith(".7z"):
+                    full_output_path_7z = full_output_path
+                else:
+                    full_output_path_7z = full_output_path + ".7z"
+
+        return full_output_path, full_output_path_7z
+
+    def _extract_downloaded_7z(
+            self,
+            archive_path: str,
+            output_path: str,
+            show_extraction_progress: bool
+    ) -> None:
+        """Extract the downloaded 7-Zip archive if requested."""
+        target_dir = os.path.dirname(archive_path)
+
+        with py7zr.SevenZipFile(  # nosec - The password "infected" is generic and always the same
+            file=archive_path,
+            mode="r",
+            password="infected",
+        ) as archive:
+            archive_filenames = archive.getnames()
+            if show_extraction_progress:
+                archive_info = archive.archiveinfo()
+                with SevenZipExtractProgressBar(
+                    unit="B",
+                    unit_scale=True,
+                    miniters=1,
+                    total_bytes=archive_info.uncompressed,
+                    desc="Extracting...",
+                    ascii=True,
+                ) as progress:
+                    # archive.extract() does not provide a callback parameter, but behaviour should
+                    # not differ since RTR 7-Zip archives should always contain exactly one inner
+                    # file.
+                    archive.extractall(path=target_dir, callback=progress)
+            else:
+                archive.extract(path=target_dir)
+
+        # Check that we truly only received exactly one output file in the 7-Zip archive.
+        # If all is well, we rename the first (and hopefully only) output file to match the name
+        # derived at the beginning of this function.
+        if archive_filenames and len(archive_filenames) == 1:
+            orig_filename = archive_filenames[0]
+            orig_path = os.path.join(target_dir, orig_filename)
+            os.rename(orig_path, output_path)
+        else:
+            raise ValueError(
+                "The downloaded 7-Zip archive contains the wrong number of files. "
+                f"Contents: {str(archive_filenames)}"
+            )
 
     def download(
         self,
@@ -120,50 +211,17 @@ class GetFile:
         if (
             not self.session_id or
             not self.sha256 or
-            not self.filename 
+            not self.filename
         ):
             raise ValueError(
                 "A session ID, SHA256 hash, and filename are all required to download a GET file. "
                 "Ensure these values are set in the object before calling the download function."
             )
 
-        # Get the name of the uploaded file from the filename value, which actually contains the
-        # full path to the file on the origin system's disk.
-        if self.filename.startswith("/"):
-            # macOS or *nix path
-            filename = self.filename.rsplit("/", maxsplit=1)[-1]
-        else:
-            # Windows filename
-            filename = self.filename.rsplit("\\", maxsplit=1)[-1]
-
-        filename_noext, ext = os.path.splitext(filename)
-
-        # Figure out what the file should be named.
-        # If a directory is provided as an output, we rename the file according to its name,
-        # hash and origin device AID.
-        # Otherwise, we use the exact filename provided as a parameter.
-        if os.path.isdir(output_path):
-            # Output path is a folder, so we should compute the filename
-            if self.device_id:
-                output_filename = f"{filename_noext}_{self.sha256}_{self.device_id}{ext}",
-            else:
-                output_filename = f"{filename_noext}_{self.sha256}{ext}"
-
-            full_output_path = os.path.join(
-                output_path,
-                output_filename,
-            )
-            full_output_path_7z = full_output_path + ".7z"
-        else:
-            full_output_path = output_path
-            if extract:
-                full_output_path_7z = full_output_path + ".7z"
-            else:
-                # We should ensure that the user's path ends in .7z if they are not extracting
-                if full_output_path.endswith(".7z"):
-                    full_output_path_7z = full_output_path
-                else:
-                    full_output_path_7z = full_output_path + ".7z"
+        full_output_path, full_output_path_7z = self._download_derive_output_paths(
+            output_path,
+            extract,
+        )
 
         # Chunked downloads can be disabled by providing a 0 as the chunk size.
         # This is rarely advantageous, but is provided for compatability.
@@ -212,43 +270,11 @@ class GetFile:
             # Downloaded, so we're done now!
             return
 
-        target_dir = os.path.dirname(full_output_path_7z)
-
-        with py7zr.SevenZipFile(  # nosec - The password "infected" is generic and always the same
-            file=full_output_path_7z,
-            mode="r",
-            password="infected",
-        ) as archive:
-            archive_filenames = archive.getnames()
-            if show_download_progress:
-                archive_info = archive.archiveinfo()
-                with SevenZipExtractProgressBar(
-                    unit="B",
-                    unit_scale=True,
-                    miniters=1,
-                    total_bytes=archive_info.uncompressed,
-                    desc=f"Extracting...",
-                    ascii=True,
-                ) as progress:
-                    # archive.extract() does not provide a callback parameter, but behaviour should
-                    # not differ since RTR 7-Zip archives should always contain exactly one inner
-                    # file.
-                    archive.extractall(path=target_dir, callback=progress)
-            else:
-                archive.extract(path=target_dir)
-
-        # Check that we truly only received exactly one output file in the 7-Zip archive.
-        # If all is well, we rename the first (and hopefully only) output file to match the name
-        # derived at the beginning of this function.
-        if archive_filenames and len(archive_filenames) == 1:
-            orig_filename = archive_filenames[0]
-            orig_path = os.path.join(target_dir, orig_filename)
-            os.rename(orig_path, full_output_path)
-        else:
-            raise ValueError(
-                "The downloaded 7-Zip archive contains the wrong number of files. Contents: %s",
-                str(archive_filenames),
-            )
+        self._extract_downloaded_7z(
+            archive_path=full_output_path_7z,
+            output_path=full_output_path,
+            show_extraction_progress=show_download_progress,
+        )
 
         # Delete the 7-Zip archive after extracting its contents if the developer told us it
         # does not need to be preserved.

--- a/poetry.lock
+++ b/poetry.lock
@@ -2208,4 +2208,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8.2"
-content-hash = "e8ce29df637eda0abbaa465885df41b9450f7c6877e425eca4a04cd0d26ff7c2"
+content-hash = "3e913b83cfcf83fc4eaf1add61f841d7e2d0789b9f9be1510b8e3f7b476671e0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -324,14 +324,14 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2025.1.31"
+version = "2025.4.26"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
-    {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
+    {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
+    {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
 ]
 
 [[package]]
@@ -538,12 +538,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+groups = ["main", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -710,14 +710,14 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "crowdstrike-falconpy"
-version = "1.4.7"
+version = "1.5.0"
 description = "The CrowdStrike Falcon SDK for Python"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "crowdstrike_falconpy-1.4.7-py3-none-any.whl", hash = "sha256:beb098fa7bba522f1be0f89b2954176f26487904155c0ce8299db8f10f5d1ad9"},
-    {file = "crowdstrike_falconpy-1.4.7.tar.gz", hash = "sha256:eb6d6f565785d5fb21466fcb166c13175c47d47acf573869e231a277810d0141"},
+    {file = "crowdstrike_falconpy-1.5.0-py3-none-any.whl", hash = "sha256:13f80645bdc3239a1c589dc46a8552f782f09dbaae6a77d3c4ec3e49382c4eee"},
+    {file = "crowdstrike_falconpy-1.5.0.tar.gz", hash = "sha256:d44175472236674055a0752fb8c9c0e9abd30bf123601bea680afbce32302135"},
 ]
 
 [package.dependencies]
@@ -744,15 +744,15 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "dill"
-version = "0.3.9"
+version = "0.4.0"
 description = "serialize all of Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 markers = "python_version >= \"3.11\""
 files = [
-    {file = "dill-0.3.9-py3-none-any.whl", hash = "sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a"},
-    {file = "dill-0.3.9.tar.gz", hash = "sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c"},
+    {file = "dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049"},
+    {file = "dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0"},
 ]
 
 [package.extras]
@@ -1047,26 +1047,26 @@ type = ["mypy", "mypy-extensions"]
 
 [[package]]
 name = "mypy-extensions"
-version = "1.0.0"
+version = "1.1.0"
 description = "Type system extensions for programs checked with the mypy type checker."
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
+    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
 ]
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
-    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
+    {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
+    {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
 ]
 
 [[package]]
@@ -1150,14 +1150,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.50"
+version = "3.0.51"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198"},
-    {file = "prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab"},
+    {file = "prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07"},
+    {file = "prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed"},
 ]
 
 [package.dependencies]
@@ -1277,54 +1277,59 @@ test = ["coverage[toml] (>=5.2)", "hypothesis", "pytest (>=6.0)", "pytest-cov"]
 
 [[package]]
 name = "pybcj"
-version = "1.0.3"
+version = "1.0.6"
 description = "bcj filter library"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "python_version >= \"3.11\""
 files = [
-    {file = "pybcj-1.0.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0bd8afeacf9173af091a08783aa9111500f5619ce0ae486bffb5ee4d08a331b4"},
-    {file = "pybcj-1.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:fc81d3c941485e7d3c2812834ca005849fe91a624977ed5227658cf952d19696"},
-    {file = "pybcj-1.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f01b75621452578ccd48a79819bc95ddac41535e16aa163ea1d86b14258afa00"},
-    {file = "pybcj-1.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e08431845702173d50d66cbbd169969d7b7cf67992f5fb7bc27a8c67e19d3d1f"},
-    {file = "pybcj-1.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:476f3c815b85e563d13238c4310b9cb47aefd0c51ac1b33312e41fcd079ea94f"},
-    {file = "pybcj-1.0.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:97bfd712bfce0d58099a02acc05b15b1d1aa3e6edf4dd8e018f43349182ffa3f"},
-    {file = "pybcj-1.0.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4d1374806cde777bc6e371f79c7f3acfb2b0906a418e04cf5331866a321633c3"},
-    {file = "pybcj-1.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:9245039e0fc87921f702133c019722e333934e61f1c90408f16618d585ff88ec"},
-    {file = "pybcj-1.0.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ae30aa62deff1ba40e4f13ef6964cf083ece541dbfb3ec3731c1fc58cc218b7d"},
-    {file = "pybcj-1.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6639f5443bc696a981a502c37e1393398a7182d61820eb39ee6d122076b6ad8c"},
-    {file = "pybcj-1.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4502c5afa2a41e569b94527bbb46185ee1a378a4fb3e9d7806ad10e892ecdf58"},
-    {file = "pybcj-1.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4ff48aaadd8fd91ac02557eec225ce7c1a3b627a6832d6cb723469891b3b242"},
-    {file = "pybcj-1.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62668bd0a1aedaa3b779615cf129d9469fd709ab8d944aa07aad68dc189de349"},
-    {file = "pybcj-1.0.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8af60d5eeed32fd1a9f6a2a11eef47cb7ebd80fe9853e709a2c1d9e29108cdf2"},
-    {file = "pybcj-1.0.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:68e1bd1b0836e216cce3d9a33795501dfc956c61ff52768737e26286e65a3771"},
-    {file = "pybcj-1.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:05738d44a987422e21f4ee15023a8c4f38a5509fdf6e6f6dfaaf43ca05cef7db"},
-    {file = "pybcj-1.0.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c68a3fe847f22a8393fe71b1b16450b6b9e8ef36faa36d0c03759f58740f6eff"},
-    {file = "pybcj-1.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:17f610ede3a766c0ff1869a4dd7750db78d39e4bfc9997f6bef050fe794c051b"},
-    {file = "pybcj-1.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:15f776925a4d6f69b344cde9035fc8f1fd02f1f2a4ccb76f4047406c0ea4241d"},
-    {file = "pybcj-1.0.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bdda28e0a20214c7f0e7de9e260122b9197106231249bf07a5ca5b84a5d38a1"},
-    {file = "pybcj-1.0.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:764cba20166fcd9ff580f4d877f17807be057da7d1234caaf54fd5fd5c591387"},
-    {file = "pybcj-1.0.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:97cf7f788560c3283a8afe3de585abb849bb1338d007e53fb6441d6ccd202e0a"},
-    {file = "pybcj-1.0.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:26d201f773d17d5e8a88785f00fa73a6647e080d933e75ddeb33da7f0baff657"},
-    {file = "pybcj-1.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:990047ac176317d42e7059b3cd357ff7c7201f3e3f08b35d083b2004d066cd39"},
-    {file = "pybcj-1.0.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3bbbf22687c9f6c57cc9b605a3a60937230843ff1b5560e2a42133fd4dd5dc73"},
-    {file = "pybcj-1.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e0a75d5ec3fa40af865f93f29e613d93fb67dc016fc60e64a4b3a4621076fecd"},
-    {file = "pybcj-1.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:631bcdea0d47ae562f118f8404fb6ef5813eb2dcfbcc53c7b9ac6bc5d4c2ef32"},
-    {file = "pybcj-1.0.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75c9430a10e69fbea336668944c0f4a9979e0bb3ab5de820315025c157baa2ae"},
-    {file = "pybcj-1.0.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5221652a9c656f6b27fda389cc4888354a287d3e0f6ea6d5b70718b6d9ec110d"},
-    {file = "pybcj-1.0.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:f6a6c3a776aa9b579c51768d2c727d3912cd8e1c2add61898dc6794b269e7ab3"},
-    {file = "pybcj-1.0.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:cb50276bd804f58690571c13e2e6eb26eca6c4a39a611591e2202136dca1b7a5"},
-    {file = "pybcj-1.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:623a4eef080f5cb0405ce19f90fa9824e2477f4a85d8b888e613cf7f146b84d1"},
-    {file = "pybcj-1.0.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:47d2a0f33dfd55dfa961502922d2b0f090857585b321f838f1c2510de4e66a9a"},
-    {file = "pybcj-1.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cf8ac15785412aa6924818fb86e250ae15e8238b7db7d410e28d3ae0743cdbd3"},
-    {file = "pybcj-1.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de02d2933fef5b26d845d2e002996c5e22c710af5b5dfc930285dff09db885cf"},
-    {file = "pybcj-1.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40a0f542dba6d079d702c1c129cc8cdc0f20bf2c5cb45defba8d5ac8e2d691a1"},
-    {file = "pybcj-1.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ace508285fd4788845a208dd00f1c7af8e68dd222cf7797ae525562a2eb22bab"},
-    {file = "pybcj-1.0.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6da2b0c120a415fa5620b76110bab487de20f8a108756499fd4df9c92fc10098"},
-    {file = "pybcj-1.0.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9c6347f1e2c78cf2584fddebe6fb9dc036b75020887facec1bab149fd6056c6"},
-    {file = "pybcj-1.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:be309c0fbf06b1e8cd1c40b24dd621271b5fb5d9fe7a0becb40ed64ac92ff50b"},
-    {file = "pybcj-1.0.3.tar.gz", hash = "sha256:b8873637f0be00ceaa372d0fb81693604b4bbc8decdb2b1ae5f9b84d196788d9"},
+    {file = "pybcj-1.0.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0fc8eda59e9e52d807f411de6db30aadd7603aa0cb0a830f6f45226b74be1926"},
+    {file = "pybcj-1.0.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0495443e8691510129f0c589ed956af4962c22b7963c5730b0c80c9c5b818c06"},
+    {file = "pybcj-1.0.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3c7998b546c3856dbe9ae879cb90393df80507f65097e7019785852769f4a990"},
+    {file = "pybcj-1.0.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:335c859f85e718924f48b3ac967cda5528ccbef1e448a4462652cca688eee477"},
+    {file = "pybcj-1.0.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:186fbb849883ac80764d96dbd253503dd9cecbcf6133504a0c9d6a2df81d5746"},
+    {file = "pybcj-1.0.6-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:437bd5f5e6579bde404404ad2de915d1306c389595c68d0eb8933fee1408e951"},
+    {file = "pybcj-1.0.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:933d6be8f07c653ff3eba16900376b3212249be1c71caf9db17f4cd52da5076c"},
+    {file = "pybcj-1.0.6-cp310-cp310-win_amd64.whl", hash = "sha256:90e169b669bbed30e22d36ba97d23dcfc71e044d3be41c8010fd6a53950725e5"},
+    {file = "pybcj-1.0.6-cp310-cp310-win_arm64.whl", hash = "sha256:06441026c773f8abeb7816566acfffe7cd65a9b69094197a9de64d0496cd4c3c"},
+    {file = "pybcj-1.0.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f0275564a1afc4b2d1a6ff465384fb73a64622a88b6e4856cb7964ba2335a06e"},
+    {file = "pybcj-1.0.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fa794b134b4ee183a4ceb739e9c3a445a24ee12e7e3231c37820f66848db4c52"},
+    {file = "pybcj-1.0.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0d8945e8157c7fa469db110fc78579d154a31d121d14705b26d7d3ec3a471c8e"},
+    {file = "pybcj-1.0.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7109177b4f77526a6ce4b565ee37483f5a5dd29bc92eaea6739b3c58618aeb7"},
+    {file = "pybcj-1.0.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c48cbc9ebed137ac8759d0f2c3d12b999581dae7b4f84d974888c402f00fdb78"},
+    {file = "pybcj-1.0.6-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6dccff82008e3cb5e5e639737320c02341b8718e189b9ece13f0230e0d57e7af"},
+    {file = "pybcj-1.0.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e4e68cfc4fb099e8200386ac2255a9f514b8bb056189273bcce874bda3597459"},
+    {file = "pybcj-1.0.6-cp311-cp311-win_amd64.whl", hash = "sha256:13747c01b60bf955878267718f28c36e2bbb81fb8495b0173b21083c7d08a4a4"},
+    {file = "pybcj-1.0.6-cp311-cp311-win_arm64.whl", hash = "sha256:6f81d6106c50c5e91c16ad58584fd7ab9eb941360188547e0184b1ede9e47f1d"},
+    {file = "pybcj-1.0.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f5d1dbc76f615595d7d8f3846c07f607fb1e2305d085c34556b32dacf8e88d12"},
+    {file = "pybcj-1.0.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1398f556ed2afe16ae363a2b6e8cf6aeda3aa21861757286bc6c498278886c60"},
+    {file = "pybcj-1.0.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e269cfc7b6286af87c5447c9f8c685f19cff011cac64947ffb4cd98919696a7f"},
+    {file = "pybcj-1.0.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7393d0b0dcaa0b1a7850245def78fa14438809e9a3f73b1057a975229d623fd3"},
+    {file = "pybcj-1.0.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e252891698d3e01d0f60eb5adfe849038cd2d429cb9510f915a0759301f1884d"},
+    {file = "pybcj-1.0.6-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ae5c891fcda9d5a6826a1b8e843b1e52811358594121553e6683e65b13eccce7"},
+    {file = "pybcj-1.0.6-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:eac3cb317df1cefed2783ce9cafdae61899dd02f2f4749dc0f4494a7c425745f"},
+    {file = "pybcj-1.0.6-cp312-cp312-win_amd64.whl", hash = "sha256:72ebec5cda5a48de169c2d7548ea2ce7f48732de0175d7e0e665ca7360eaa4c4"},
+    {file = "pybcj-1.0.6-cp312-cp312-win_arm64.whl", hash = "sha256:8f1f75a01e45d01ecf88d31910ca1ace5d345e3bfb7c18db0af3d0c393209b63"},
+    {file = "pybcj-1.0.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3e6800eb599ce766e588095eedb2a2c45a93928d1880420e8ecfad7eff0c73dc"},
+    {file = "pybcj-1.0.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:69a841ca0d3df978a2145488cec58460fa4604395321178ba421384cff26062f"},
+    {file = "pybcj-1.0.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:887521da03302c96048803490073bd0423ff408a3adca2543c6ee86bc0af7578"},
+    {file = "pybcj-1.0.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39a5a9a2d0e1fa4ddd2617a549c11e5022888af86dc8e29537cfee7f5761127d"},
+    {file = "pybcj-1.0.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57757bc382f326bd93eb277a9edfc8dff6c22f480da467f0c5a5d63b9d092a41"},
+    {file = "pybcj-1.0.6-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb1872b24b30d8473df433f3364e828b021964229d47a07f7bfc08496dbfd23e"},
+    {file = "pybcj-1.0.6-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:5fedfeed96ab0e34207097f663b94e8c7076025c2c7af6a482e670e808ea5bb0"},
+    {file = "pybcj-1.0.6-cp313-cp313-win_amd64.whl", hash = "sha256:caefc3109bf172ad37b52e21dc16c84cf495b2ea2890cc7256cdf0188914508d"},
+    {file = "pybcj-1.0.6-cp313-cp313-win_arm64.whl", hash = "sha256:b24367175528da452a19e4c55368d5c907f4584072dc6aeee8990e2a5e6910fc"},
+    {file = "pybcj-1.0.6-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:558128fbc201c9f11c1b1df30377fab3821ebb736c28e5eaf9fff9cc9e56b806"},
+    {file = "pybcj-1.0.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d05f4026154d77c97486d5ce04261b473e3ec8c2f7cf0f937b7baa439c616559"},
+    {file = "pybcj-1.0.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:96ce9c428800ecc0d52cec9947ee167f3a7f913cc2ba58b9a462e7f19c52ac4b"},
+    {file = "pybcj-1.0.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:05038a58d78ab15a847ed90c17d924be5b7848f27a43517dc88a5589fba1ca78"},
+    {file = "pybcj-1.0.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:591f58891ff52585a38894b28c8b952e4c7be93f65d6d43751672cde8edeff36"},
+    {file = "pybcj-1.0.6-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:e1f416250101631ac04705a19d78ec407d261da9dffa0e1fa1f1f2d9409ec70d"},
+    {file = "pybcj-1.0.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:27c489dd9e0d9745ebf7cd4344f23b6cb655edb2dea879ca63a0558a993e0d4b"},
+    {file = "pybcj-1.0.6-cp39-cp39-win_amd64.whl", hash = "sha256:56fe3ff939653c6b0e35aa105170af3494ee9e2469494ef1d0fa2bac3fdd99d0"},
+    {file = "pybcj-1.0.6-cp39-cp39-win_arm64.whl", hash = "sha256:6c88e1a04b90547f0470e4d2bd190bbe6b73c8666d4f7196c3ca43a379a15de5"},
+    {file = "pybcj-1.0.6.tar.gz", hash = "sha256:70bbe2dc185993351955bfe8f61395038f96f5de92bb3a436acb01505781f8f2"},
 ]
 
 [package.extras]
@@ -1945,15 +1950,15 @@ type = ["importlib-metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.deve
 
 [[package]]
 name = "setuptools"
-version = "78.1.0"
+version = "80.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 markers = "python_version >= \"3.11\""
 files = [
-    {file = "setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8"},
-    {file = "setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54"},
+    {file = "setuptools-80.1.0-py3-none-any.whl", hash = "sha256:ea0e7655c05b74819f82e76e11a85b31779fee7c4969e82f72bab0664e8317e4"},
+    {file = "setuptools-80.1.0.tar.gz", hash = "sha256:2e308396e1d83de287ada2c2fd6e64286008fe6aca5008e0b6a8cb0e2c86eedd"},
 ]
 
 [package.extras]
@@ -2116,16 +2121,38 @@ files = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.67.1"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
+    {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
+discord = ["requests"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "typing-extensions"
-version = "4.13.0"
+version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 markers = "python_version < \"3.11\""
 files = [
-    {file = "typing_extensions-4.13.0-py3-none-any.whl", hash = "sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5"},
-    {file = "typing_extensions-4.13.0.tar.gz", hash = "sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b"},
+    {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
+    {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
 
 [[package]]
@@ -2149,15 +2176,15 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "python_version >= \"3.11\""
 files = [
-    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
-    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
+    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
+    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
 ]
 
 [package.extras]
@@ -2181,4 +2208,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8.2"
-content-hash = "617a5795c5cea006a61d77c121d0cdcd04adda4f52d526a875af5738ed5dfd4d"
+content-hash = "e8ce29df637eda0abbaa465885df41b9450f7c6877e425eca4a04cd0d26ff7c2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.8.2"
 py7zr = "^0.22.0"
-crowdstrike-falconpy = "^1.4.0"
+crowdstrike-falconpy = "^1.5.0"
 caracara-filters = "^1.0.0"
 tqdm = "^4.67.1"
 
@@ -38,6 +38,7 @@ requires = ["poetry-core>=1.0.0", "setuptools"]
 
 [tool.pylint.messages_control]
 max-line-length = 100
+max-args = 6
 disable = [
     # Disable duplicate-code as our policies modules will have lots of overlap, by design.
     # It is not really practical to try to appease this rule when creating an SDK wrapper.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caracara"
-version = "1.0.0"
+version = "1.0.1"
 description = "The CrowdStrike Falcon Developer Toolkit"
 authors = [ "CrowdStrike <falconpy@crowdstrike.com>" ]
 readme = "README.md"
@@ -10,6 +10,7 @@ python = "^3.8.2"
 py7zr = "^0.22.0"
 crowdstrike-falconpy = "^1.4.0"
 caracara-filters = "^1.0.0"
+tqdm = "^4.67.1"
 
 [tool.poetry.group.dev.dependencies]
 bandit = "^1.7.9"


### PR DESCRIPTION
At long last, we can finally present streaming file downloads! This has been a highly requested feature both internally and externally (#94).

In this release, file downloads will stream based on the Python Requests chunking functionality, and we also provide an out of the box tqdm-powered progress bar implementation ready for tools like Falcon Toolkit.

This also provides the backend to fix a bug in Falcon Toolkit raised here: https://github.com/CrowdStrike/Falcon-Toolkit/issues/190